### PR TITLE
Add role to CMK stack

### DIFF
--- a/templates/SynapseCMK-template.json
+++ b/templates/SynapseCMK-template.json
@@ -2,16 +2,61 @@
 	"AWSTemplateFormatVersion": "2010-09-09",
 	"Description": "The master encryption key used to encypt/decypt all Synapse mater secrets",
 	"Parameters": {
-                "ArnsAllowedToDecrypt": {
-                        "Description": "The arns of the users allowed to decrypt.",
-                        "Type": "CommaDelimitedList"
-				},
 				"Stack": {
 					"Description": "The stack",
 					"Type": "String"
 				}
         },
 	"Resources": {
+		"SynapseDeploymentPolicy": {
+			"Type": "AWS::IAM::Policy",
+			"Properties": {
+				"PolicyName": "SynapseDeploymentPolicy",
+				"PolicyDocument": {
+					"Version": "2012-10-17",
+					"Statement": [
+						{"Effect": "Allow", "Action": "s3:*", "Resource": "*"},
+						{"Effect": "Allow", "Action": "sns:*", "Resource": "*"},
+						{"Effect": "Allow", "Action": "rds:*", "Resource": "*"},
+						{"Effect": "Allow", "Action": "ec2:*", "Resource": "*"},
+						{"Effect": "Allow", "Action": "cloudwatch:*", "Resource": "*"},
+						{"Effect": "Allow", "Action": "elasticbeanstalk:*", "Resource": "*"},
+						{"Effect": "Allow", "Action": "route53:*", "Resource": "*"},
+						{"Effect": "Allow", "Action": "cloudformation:*", "Resource": "*"},
+						{"Effect": "Allow", "Action": ["iam:CreateRole", "iam:DeleteRole"], "Resource": "*"},
+						{"Effect": "Allow", "Action": ["iam:CreateInstanceProfile", "iam:DeleteInstanceProfile"], "Resource": "*"}
+					]
+				},
+				"Roles": [
+					{"Ref": "SynapseDeploymentRole"}
+				]
+			}
+		},
+		"SynapseDeploymentRole": {
+			"Type": "AWS::IAM::Role",
+			"Properties": {
+				"AssumeRolePolicyDocument": {
+					"Version:": "2012-10-17",
+					"Statement": {
+						"Effect": "Allow",
+						"Principal": {
+							"Service": ["ec2.amazonaws.com"] 
+						},
+						"Action": ["sts:AssumeRole"]
+					}
+				},
+				"Path": "/"
+			}
+		},
+		"SynapseDeploymentProfile": {
+			"Type": "AWS::IAM::InstanceProfile",
+			"Properties": {
+				"Roles": [
+					{"Ref": "SynapseDeploymentRole"}
+				],
+				"Path": "/"
+			}
+		},
 		"SynapseCMK": {
 			"Type": "AWS::KMS::Key",
 			"Properties": {
@@ -47,7 +92,7 @@
 							"Sid": "Allow use of the key",
 							"Effect": "Allow",
 							"Principal": {								
-								"AWS": {"Ref":"ArnsAllowedToDecrypt"}
+								"AWS": {"Fn::GetAtt": ["SynapseDeploymentRole", "Arn"]}
 							},
 							"Action": [
 								"kms:Encrypt",

--- a/templates/SynapseCMK-template.json
+++ b/templates/SynapseCMK-template.json
@@ -1,0 +1,74 @@
+{
+	"AWSTemplateFormatVersion": "2010-09-09",
+	"Description": "The master encryption key used to encypt/decypt all Synapse mater secrets",
+	"Parameters": {
+                "ArnsAllowedToDecrypt": {
+                        "Description": "The arns of the users allowed to decrypt.",
+                        "Type": "CommaDelimitedList"
+				},
+				"Stack": {
+					"Description": "The stack",
+					"Type": "String"
+				}
+        },
+	"Resources": {
+		"SynapseCMK": {
+			"Type": "AWS::KMS::Key",
+			"Properties": {
+				"Description": "The master encryption key used to encypt/decypt all Synapse mater secrets",
+				"EnableKeyRotation": false,
+				"KeyPolicy": {
+					"Version": "2012-10-17",
+					"Id": "key-default-1",
+					"Statement": [
+						{
+							"Sid": "Allow administration of the key",
+							"Effect": "Allow",
+							"Principal": {
+								"AWS": {
+									"Fn::Join": [
+										"",
+										[
+											"arn:aws:iam::",
+											{
+												"Ref": "AWS::AccountId"
+											},
+											":root"
+										]
+									]
+								}
+							},
+							"Action": [
+								"kms:*"
+							],
+							"Resource": "*"
+						},
+						{
+							"Sid": "Allow use of the key",
+							"Effect": "Allow",
+							"Principal": {								
+								"AWS": {"Ref":"ArnsAllowedToDecrypt"}
+							},
+							"Action": [
+								"kms:Encrypt",
+								"kms:Decrypt",
+								"kms:ReEncrypt*",
+								"kms:DescribeKey"
+							],
+							"Resource": "*"
+						}
+					]
+				}
+			}
+		},
+		"SynapseCMKAlias": {
+			"Type": "AWS::KMS::Alias",
+			"Properties": {
+				"AliasName": { "Fn::Join" : [ "/", ["alias", {"Ref": "Stack"}, "synapse" ] ] },
+				"TargetKeyId": {
+					"Ref": "SynapseCMK"
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
This adds a policy/role/instanceprofile for the deployer (stack builder), and gives the role the right to use the KMS key. The existing KMS stack will be updated using this script.
Once the KMS stack is updated, create an EC2 instance for the build system using the instance profile,
then the build job should be able to deploy a stack without credentials.

When OK, script can be used to create the initial KMS stack on prod. 