### PR TITLE
Fix previous PR, just need to remove MFA block

### DIFF
--- a/templates/accounts.yaml
+++ b/templates/accounts.yaml
@@ -106,6 +106,7 @@ Resources:
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/PowerUserAccess
         - arn:aws:iam::aws:policy/IAMReadOnlyAccess
+        - !Ref AWSIAMEnforceMfaPolicy
   AWSIAMAdminRole:
     Type: "AWS::IAM::Role"
     Properties:
@@ -238,13 +239,6 @@ Resources:
             Condition:
               Bool:
                 'aws:MultiFactorAuthPresent': 'true'
-          - Sid: BlockAnyAccessOtherThanAboveUnlessSignedInWithMFA
-            Effect: Deny
-            NotAction: 'iam:*'
-            Resource: '*'
-            Condition:
-              BoolIfExists:
-                'aws:MultiFactorAuthPresent': 'false'
 Outputs:
   AWSIAMEnforceMfaPolicy:
     Value: !Ref AWSIAMEnforceMfaPolicy


### PR DESCRIPTION
We can't block '! iam:*' if no MFA because we can't build locally, but removing access to the whole policy prevents user from doing their own IAM. Re-adding the ref to the policy but remove the part about
needing to be MFA'ed to do '! iam:*'.