### PR TITLE
remove instance profile

### DIFF
--- a/templates/accounts.yaml
+++ b/templates/accounts.yaml
@@ -156,13 +156,6 @@ Resources:
       Roles:
         -
           !Ref AWSIAMAdminRole
-  AWSIAMInstanceProfile:
-    Type: "AWS::IAM::InstanceProfile"
-    Properties:
-      Path: "/"
-      Roles:
-        -
-          !Ref "AWSIAMAdminRole"
   AWSIAMAllUsersGroup:
     Type: 'AWS::IAM::Group'
     Properties:


### PR DESCRIPTION
This profile isn't used. It also shouldn't be used,
EC2 instances should not have admin privileges.