### PR TITLE
Extra rights to deploy as dev

### DIFF
--- a/templates/accounts.yaml
+++ b/templates/accounts.yaml
@@ -137,6 +137,32 @@ Resources:
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/PowerUserAccess
         - arn:aws:iam::aws:policy/IAMReadOnlyAccess
+        - !Ref AWSIAMDevelopersDeployRightsPolicy
+
+  AWSIAMDevelopersDeployRightsPolicy:
+    Type: "AWS::IAM::ManagedPolicy"
+    Properties:
+      PolicyDocument: 
+        Version: "2012-10-17"
+        Statement:
+          - 
+            Effect: "Allow"
+            Action:
+              - "iam:CreateRole",
+              - "iam:DeleteRole",
+              - "iam:UpdateRole",
+              - "iam:GetRole",
+              - "iam:PassRole",
+              - "iam:CreateRolePolicy",
+              - "iam:DeleteRolePolicy",
+              - "iam:PutRolePolicy",
+              - "iam:CreateInstanceProfile",
+              - "iam:DeleteInstanceProfile",
+              - "iam:GetInstanceProfile",
+              - "iam:RemoveRoleFromInstanceProfile",
+              - "iam:AddRoleToInstanceProfile"
+            Resource: "*"
+
   AWSIAMAdminRole:
     Type: "AWS::IAM::Role"
     Properties:


### PR DESCRIPTION
For developers to run the deployer as themselves (which they'll need to deploy shared resources), they need some IAM rights. Lifted them from SynpaseDeployment role policy.