### PR TITLE
IT-1039: Give the idp roles access to the keys

### DIFF
--- a/templates/SynapseCMK-template.json
+++ b/templates/SynapseCMK-template.json
@@ -180,6 +180,13 @@
                                         "cloudfront:*"
                                     ],
                                     "Resource": "*"
+                                },
+                                {
+                                    "Effect": "Allow",
+                                    "Action": [
+                                        "sts:*"
+                                    ],
+                                    "Resource": "*"
                                 }
                             ]
                         }

--- a/templates/SynapseCMK-template.json
+++ b/templates/SynapseCMK-template.json
@@ -247,6 +247,28 @@
                                         },
                                         {
                                             "Ref": "AWS::AccountId"
+                                        },
+                                        {
+                                            "Fn::Join": [
+                                                "",
+                                                [
+                                                    {
+                                                        "Fn::ImportValue": "us-east-1-jumpcloud-idp-SynapseDevDeveloperSamlProviderRoleId"
+                                                    },
+                                                    ":*"
+                                                ]
+                                            ]
+                                        },
+                                        {
+                                            "Fn::Join": [
+                                                "",
+                                                [
+                                                    {
+                                                        "Fn::ImportValue": "us-east-1-jumpcloud-idp-SynapseDevAdminSamlProviderRoleId"
+                                                    },
+                                                    ":*"
+                                                ]
+                                            ]
                                         }
                                     ]
                                 }
@@ -277,6 +299,12 @@
                                                 ":root"
                                             ]
                                         ]
+                                    },
+                                    {
+                                        "Fn::ImportValue": "us-east-1-jumpcloud-idp-SynapseDevDeveloperSamlProviderRoleArn"
+                                    },
+                                    {
+                                        "Fn::ImportValue": "us-east-1-jumpcloud-idp-SynapseDevAdminSamlProviderRoleArn"
                                     }
                                 ]
                             },


### PR DESCRIPTION
[IT-1039] This gives the roles we use when coming in from JumpCloud the right to access the stack keys. This is necessary to delete a stack from the console. Same will be done in synapseprod for Admins only.
Note: this stack is deployed manually.


[IT-1039]: https://sagebionetworks.jira.com/browse/IT-1039